### PR TITLE
resolve env placeholder parameter

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -453,7 +453,7 @@ class Kernel
         if ($this->debug) {
             $this->setContainer(new ContainerBuilder(new EnvPlaceholderParameterBag($this->getContainerParameters())));
             $this->loadContainerConfiguration();
-            $this->container->compile();
+            $this->container->compile(true);
         } else {
             $filename = $this->getContainerCacheFilename();
 
@@ -463,7 +463,7 @@ class Kernel
             } else {
                 $this->setContainer(new ContainerBuilder(new EnvPlaceholderParameterBag($this->getContainerParameters())));
                 $this->loadContainerConfiguration();
-                $this->container->compile();
+                $this->container->compile(true);
 
                 if ($this->containerIsCacheable()) {
                     $dumper = new PhpDumper($this->container);


### PR DESCRIPTION
When using %env(PARAM_1)% in parameters.yml, those env vars where not correctly set with debug mode enabled. With debug mode disabled, only a second call reading in the cached version, resolved those env vars.

**How to reproduce:**

- set parameter, e.g. the database config, via %env()%
- set the env vars
- deactivate debug-mode
- call "./app/console migrations:status" on the command line
- call "./app/console migrations:status" on the command line a second time

**Observed behaviour:**
- the first call to migrations:status fails with an error message regarding unresolvable hostnames
- the second call works as expected

**Expected behaviour**
- each single call should work.